### PR TITLE
Add support for dicts and pairs in sub. 

### DIFF
--- a/src/subs.jl
+++ b/src/subs.jl
@@ -35,17 +35,17 @@ subs{T <: SymbolicObject}(ex::T, y::@compat(Tuple{SymbolicTypes, Any})) =
     object_meth(ex, :subs, Sym(y[1]), convert(Sym,y[2]))
 subs{T <: SymbolicObject}(ex::T, y::@compat(Tuple{SymbolicTypes, Any}), args...) = subs(subs(ex, y), args...)
 subs{T <: SymbolicObject, S <: SymbolicTypes}(ex::T, y::S, val) = subs(ex, (y,val))
+subs{T <: SymbolicObject}(ex::T, d::Vararg{Pair}) = subs(ex, [(p.first, p.second) for p in d]...)
+subs{T <: SymbolicObject}(ex::T, dict::Dict) = subs(ex, dict...)
 
 ## curried version to use with |>
 subs(x::SymbolicTypes, y) = ex -> subs(ex, x, y)
 subs(;kwargs...) = ex -> subs(ex; kwargs...)
-
+subs(d::Vararg{Pair}) = ex -> subs(ex, [(p.first, p.second) for p in d]...)
+subs(dict::Dict) = ex -> subs(ex, dict...)
 
 ## Convenience method for keyword arguments
-function subs{T <: SymbolicObject}(ex::T; kwargs...)
-    ts = [(Sym(k),v) for (k,v) in kwargs]
-    subs(ex, ts...)
-end
+subs{T <: SymbolicObject}(ex::T; kwargs...) = subs(ex, kwargs...)
 
 
 ## replace alias for subs
@@ -74,6 +74,8 @@ if VERSION >= v"0.4.0-dev"
         xs = free_symbols(ex)
         subs(ex, collect(zip(xs, args))...)
     end
+    Base.call(ex::SymbolicObject, x::Dict) = subs(ex, x)
+    Base.call(ex::SymbolicObject, x::Vararg{Pair}) = subs(ex, x...)
 end
 
 #####

--- a/test/tests.jl
+++ b/test/tests.jl
@@ -296,3 +296,30 @@ if isdefined(:mpmath)
     bei(2, 3.5)
     bei(1+im, 2+3im)
 end
+
+#Test subs for pars and dicts
+ex = 1
+dict1 = Dict{ASCIIString,Any}()
+dict2 = Dict{Any,Any}()
+#test subs
+for i=1:4
+    x = Sym("x$i")
+    ex=ex*x
+    dict2[x] = i
+    dict1[string(x)] = i
+end
+for d in [dict1, dict2]
+    @test ex |> subs(d) == factorial(4)
+    @test ex |> subs(d...) == factorial(4)    
+    @test subs(ex, d) == factorial(4)
+    @test subs(ex, d...) == factorial(4)
+    @test ex(d) == factorial(4)
+    @test ex(d...) == factorial(4)
+end
+
+a = Sym("a")
+b = Sym("b")
+line = x -> a + b * x
+sol = solve([line(0)-1, line(1)-2],[a,b])
+ex = line(10)
+@test ex |> subs(sol) == ex(sol) == ex(sol...) == 11


### PR DESCRIPTION
This is especially helpful when a solution need to be inserted into an equation. The test in https://github.com/dhoegh/SymPy.jl/blob/310caf7e8031e1e814eea9cdd4bb665d60a14a37/test/tests.jl#L323-L325.

A small comment maybe the substitution interface should be unified a bit. Maybe the keyword argument function could be removed as 0.4 allows for Pair construction with `"x"=>1`. So this `(x+1)(x=>1)==2` will work with this PR . This seem also to be more inline with the python version that do no allow keyword arguments. http://docs.sympy.org/dev/modules/core.html.

BTW great work with the package I ported some of my old maple examples to SymPy with no problems and I like the interface better than what python provide.