### PR TITLE
Make mpmath optional when using Conda

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,18 @@ julia:
   - 0.4
   - nightly
 env:
+    global:
     - PYTHON=conda
+    matrix:
+    - MPMATH=true
+    - MPMATH=false
 notifications:
   email: false
+before_install:
+    #install mpmath to test functionallity
+  - if [ $MPMATH = "true" ]; then julia -e 'Pkg.add("Conda"); using Conda; Conda.add("mpmath")';fi
+script:
+  - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
+  - julia -e 'Pkg.clone(pwd()); Pkg.build("SymPy"); Pkg.test("SymPy"; coverage=true)'
 after_success: 
   - julia -e 'Pkg.add("Coverage"); cd(Pkg.dir("SymPy")); using Coverage; Coveralls.submit(process_folder())'

--- a/src/SymPy.jl
+++ b/src/SymPy.jl
@@ -212,7 +212,6 @@ function __init__()
         if PyCall.conda
             info("Installing sympy via the Conda package...")
             Conda.add("sympy")
-            Conda.add("mpmath")
             copy!(sympy, pyimport("sympy"))
         else
             error("""Failed to pyimport("sympy"): SymPy will not work until you have a functioning sympy module.

--- a/src/mpmath.jl
+++ b/src/mpmath.jl
@@ -51,21 +51,20 @@ function init_mpmath()
         try
 	    copy!(mpmath, pyimport("mpmath"))			
         catch e
-            error("Failed to pyimport(\"mpmath\"): This is a soft dependency.  ", e)
-        if PyCall.conda
-            info("Installing mpmath via the Conda package...")
-            Conda.add("mpmath")
-            copy!(mpmath, pyimport("mpmath"))
-        else
-            error("""Failed to pyimport("mpmath"): SymPy will have less functionality.
+            if PyCall.conda
+                info("Installing mpmath via the Conda package...")
+                Conda.add("mpmath")
+                copy!(mpmath, pyimport("mpmath"))
+            else
+                error("""Failed to pyimport("mpmath"): SymPy will have less functionality.
 
-                  For automated mpmath installation, try configuring PyCall to use the Conda Python distribution within Julia.  Relaunch Julia and run:
-                        ENV["PYTHON"]=""
-                        Pkg.build("PyCall")
-                        using SymPy
+                      For automated mpmath installation, try configuring PyCall to use the Conda Python distribution within Julia.  Relaunch Julia and run:
+                            ENV["PYTHON"]=""
+                            Pkg.build("PyCall")
+                            using SymPy
 
-                  pyimport exception was: """, e)
-        end
+                      pyimport exception was: """, e)
+            end
         end
     end
     if mpmath != PyCall.PyNULL()


### PR DESCRIPTION
While doing #39 I was not aware, that mpmath was an optional dependency and hence made Sympy install it through conda on line: https://github.com/jverzani/SymPy.jl/blob/fe7353d110c0c89e2ef6346789c2b000cf0d4726/src/SymPy.jl#L215. Instead of using the code already placed in https://github.com/jverzani/SymPy.jl/blob/fe7353d110c0c89e2ef6346789c2b000cf0d4726/src/mpmath.jl#L50-L71. This PR corrects it to be an optional dependency and do not install mpmath as default, I have also added so Sympy gets tested with and without mpmath present using build matrix on travis, see https://github.com/dhoegh/SymPy.jl/blob/ee50f3be42b5e5b87ae729f483ad66799f02a4e8/.travis.yml#L12-L19.