### PR TITLE
test undocumented git depth option on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,8 @@ julia:
   - 0.3
   - 0.4
   - nightly
+git:
+    depth: 99999
 env:
     global:
     - PYTHON=conda


### PR DESCRIPTION
looks like you're hitting travis failures at git fetch --unshallow, there's an open issue at https://github.com/travis-ci/travis-ci/issues/4942 that suggests this workaround